### PR TITLE
Adding store option to fix missing key store exception issue #24

### DIFF
--- a/chessli/cli/games.py
+++ b/chessli/cli/games.py
@@ -93,6 +93,7 @@ def ankify(
         "--export-only/--directly",
         help="Select to only export the created anki cards",
     ),
+    store: bool = typer.Option(False, help="Select if fetched games should be stored"),
 ):
     """Parse your games to find mistakes and create Anki cards"""
 


### PR DESCRIPTION
Fix for #24 where there is a missing key.

If there is any reason to not have the option to store, the alternative is just adding:
```
@app.command()
def ankify( ... ):
    cli_config["store"] = False
    ...
```